### PR TITLE
修复加载公众号数据begin计数问题

### DIFF
--- a/components/ArticleList.vue
+++ b/components/ArticleList.vue
@@ -72,7 +72,8 @@ async function loadData() {
     const [articles, completed, totalCount] = await getArticleList(fakeid, loginAccount.value.token, begin.value, keyword.value)
     articleList.push(...articles)
     noMoreData.value = completed
-    begin.value += articles.length
+    const count = articles.filter(article => article.itemidx === 1).length
+    begin.value += count
 
     totalPages.value = Math.ceil(totalCount / ARTICLE_LIST_PAGE_SIZE)
 


### PR DESCRIPTION
#24 加载公众号数据时没有对begin索引进行过滤，下一次请求数据的起始索引错误，而导致公众号未完整加载